### PR TITLE
Disable form redirect in login.html

### DIFF
--- a/app/login.html
+++ b/app/login.html
@@ -13,7 +13,7 @@
 </div>
 <div id="container">
     <!--<h1>Password Authentication</h1> -->
-    <form>
+    <form onsubmit="return false;">
         <ul>
             <li>
                 <span style="text-align:center;"><label for="username">Username</label></span>


### PR DESCRIPTION
Disable form redirect in login.html

Some Windows users reported a problem on login where they're sometimes
redirected back to the login page after logging in with correct
credentials (issue #160). It looks like a race condition in login code
which is probably fixed by this commit.

We use `<form>` and `<input type="submit" ...>` for login page. On
submit, the browser window is redirected to e.g.
`login.html?user=foo&pass=pw`. Submit button also has an onclick handler
which sends a message with credentials to the main process which, upon
successful verification, replies with the OK message, in which case the
`window.location` is set to the `zwallet.html`. So there can be 2
redirections, one from the form submit and one on a successful login.
