### PR TITLE
Fix address name display

### DIFF
--- a/app/zwallet.html
+++ b/app/zwallet.html
@@ -224,7 +224,7 @@
                     <div class=addrBalance><span class=addrBalanceAmount></span> ZEN</div>
                     <div class=addrNameLine>
                         <img class=addrDetailButton src="resources/About_icon_(The_Noun_Project).svg" />
-                        <span class=addrName data-tr=wallet.tabOverview.unnamedAddress>Unnamed address</span>
+                        <span class=addrName></span>
                     </div>
                     <span class="addrText monospace"></span>
                 </div>

--- a/app/zwallet.js
+++ b/app/zwallet.js
@@ -187,13 +187,15 @@ function zenToFiat(fiat) {
     });
 }
 
+function getAddressName(addrObj) {
+    return addrObj.name ? addrObj.name : tr("wallet.tabOverview.unnamedAddress", "Unnamed address");
+}
+
 function createAddrItem(addrObj) {
     const addrItem = cloneTemplate("addrItemTemplate");
     addrItem.dataset.addr = addrObj.addr;
 
-    if (addrObj.name) {
-        addrItem.getElementsByClassName("addrName")[0].textContent = addrObj.name;
-    }
+    addrItem.getElementsByClassName("addrName")[0].textContent = getAddressName(addrObj);
     addrItem.getElementsByClassName("addrText")[0].textContent = addrObj.addr;
     addrItem.getElementsByClassName("addrNameLine")[0]
         .addEventListener("click", () => showAddrDetail(addrObj.addr));
@@ -367,8 +369,7 @@ function setAddressName(addr, name) {
     const [addrObj, addrNode] = getAddrData(addr);
     assert(addrObj);
     addrObj.name = name;
-    const displayName = name ? name : tr("wallet.tabOverview.unnamedAddress", "Unnamed address");
-    addrNode.querySelector(".addrName").textContent = displayName;
+    addrNode.querySelector(".addrName").textContent = getAddressName(addrObj);
     sortAddresses();
     scrollIntoViewIfNeeded(addrListNode, addrNode);
 }


### PR DESCRIPTION
Each time a settings object is received, the page is translated (which
is bad). Address name nodes have translation key for the "Unnamed
address" even when their contents have names. So each time a settings is
updated, the names are reset to "Unnamed address".