### PR TITLE
Fix toolbar grid layout

### DIFF
--- a/app/resources/zstyle.css
+++ b/app/resources/zstyle.css
@@ -55,6 +55,7 @@ div {
 }
 
 button {
+    cursor: pointer;
     font: inherit;
     outline: none;
     color: var(--button-fg);
@@ -71,6 +72,7 @@ button:not(:disabled):focus {
 }
 
 button:disabled {
+    cursor: default;
     background: lightgray;
 }
 

--- a/app/resources/zwallet.css
+++ b/app/resources/zwallet.css
@@ -12,11 +12,13 @@ header {
     grid-area: header;
     display: grid;
     grid-template-columns: 1fr 1fr 1fr;
+    grid-column-gap: 10px;
     align-items: center;
 }
 
 header > *:nth-child(1) {
     justify-self: start;
+    white-space: nowrap;
 }
 
 header > *:nth-child(2) {
@@ -25,6 +27,7 @@ header > *:nth-child(2) {
 
 header > *:nth-child(3) {
     justify-self: end;
+    white-space: nowrap;
 }
 
 .headerCenter > :not(:first-child) {
@@ -333,17 +336,6 @@ header button {
     font-weight: bolder;
 }
 
-/* 
-.addrSelectList {
-    overflow: auto;
-    overflow-x: hidden;
-    display: grid;
-    grid-template-columns: auto auto auto;
-    grid-gap: 10px;
-    align-items: baseline;
-    height: 100%;
-}
-*/
 /*
  Make flexbox look like table.
  Wait for Electron to support Chromium that supports "display: contents" (62 partly does).


### PR DESCRIPTION
Hi, this PR is for fixing #216 
> When you shrink the window the Arizen logo keeps too much space which results in left and right buttons wrapping. Grid layout template should keep the logo in the center, but allow side buttons to take the empty space.

Now it's like this:
![image](https://user-images.githubusercontent.com/10692276/35190177-b2e1f196-feaf-11e7-91fc-292d27e82aeb.png)
