### PR TITLE
Fix npm script `start` 

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "main": "app/main.js",
   "scripts": {
     "postinstall": "electron-builder install-app-deps",
-    "start": "npm install && electron ./app",
+    "start": "npm install && electron .",
     "pack": "build --dir",
     "dist": "build",
     "publish": "publish",


### PR DESCRIPTION
Hmm, currently if the user run something like
`yarn start` or `npm start`, they will get something like
![image](https://user-images.githubusercontent.com/10692276/35190281-953e635c-feb1-11e7-8b90-50d47dd836e5.png)

This tiny PR fixes it.