### PR TITLE
Warning messages in critical steps

### DIFF
--- a/app/create_wallet.js
+++ b/app/create_wallet.js
@@ -16,6 +16,8 @@ let num = false;
 let ide = false;
 let spec = false;
 
+const userWarningCreateWallet = "To make sure that you will never lose your wallet make sure to keep backup of your wallet(s) file. (.uawd or .awd + username + password). \\ By clicking OK you declare that you fully understand this. If you are not sure please refer to the Arizen manual for further information. You can always contact the contributor of Arizen in the official github account: https://github.com/ZencashOfficial/arizen/."
+
 function checkLoginInfo() {
     document.getElementById("btSubmit").disabled = !(usr && len && lett && capl && num && ide && spec);
 }
@@ -40,6 +42,7 @@ ipcRenderer.on("write-login-response", function (event, resp) {
     if (data.response === "OK") {
         location.href = "./login.html";
         console.log("Wallet creation was successful - redirecting to login.html");
+        alert(userWarningCreateWallet)
     } else {
         console.log("Wallet creation failed");
         document.getElementById("wallet_creation_info").innerHTML = data.msg;

--- a/app/main.js
+++ b/app/main.js
@@ -24,6 +24,9 @@ const {List} = require("immutable");
 const {translate} = require("./util.js");
 const {DateTime} = require("luxon");
 
+const userWarningImportFileWithPKs = "New address(es) and a private key(s) is/are imported. Your previous back-ups do not include the newly imported addresses or the corresponding private keys. Please use the backup feature of Arizen to make new backup file and replace your existing Arizen wallet backup. By pressing OK you declare that you understand this."
+const userWarningExportWalletUnencrypted = "The UNENCRYPTED wallet that was just exported contains your private keys in plain text. That means that anyone with this file can control your ZENs. By pressing OK you declare that you understand this."
+const userWarningExportWalletEncrypted = "The ENCRYPTED wallet that was just exported contains your private keys encrypted. That means that in order to access your private keys you need to know the corresponding username and password. In case you don't know them you cannot control the ZENs that are controled by these private keys. By pressing OK you declare that you understand this."
 
 // Press F12 to open the DevTools. See https://github.com/sindresorhus/electron-debug.
 require("electron-debug")();
@@ -400,6 +403,11 @@ function exportWalletArizen(ext, encrypt) {
                 });
             } else {
                 exportWallet(filename, encrypt);
+            }
+            if(encrypt){
+                mainWindow.webContents.send("main-sends-alert", userWarningExportWalletEncrypted);
+            } else {
+                mainWindow.webContents.send("main-sends-alert", userWarningExportWalletUnencrypted);
             }
         }
     });
@@ -983,6 +991,7 @@ function importPKs() {
             // TODO: save only if at least one key was inserted
             saveWallet();
             sendWallet();
+            mainWindow.webContents.send("main-sends-alert", userWarningImportFileWithPKs);
         }
     });
 }

--- a/app/zcommon.js
+++ b/app/zcommon.js
@@ -7,6 +7,8 @@ const {DateTime} = require("luxon");
 const {translate} = require("./util.js");
 const zencashjs = require("zencashjs");
 
+const userWarningImportPK = "A new address and a private key is imported. Your previous back-ups do not include this newly imported address or the corresponding private key. Please use the backup feature of Arizen to make new backup file and replace your existing Arizen wallet backup. By pressing OK you declare that you understand this."
+
 function assert(condition, message) {
     if (!condition) {
         throw new Error(message || "Assertion failed");
@@ -321,6 +323,7 @@ function showImportSinglePKDialog() {
                     alert(tr("wallet.importSinglePrivateKey.warningNotValidAddress", "Z address exist in your wallet"))
                 } else {
                     ipcRenderer.send("import-single-key", name, pk);
+                    alert(userWarningImportPK)
                     dialog.close();
                 }
             } else {

--- a/app/zwallet.js
+++ b/app/zwallet.js
@@ -61,7 +61,7 @@ const withdrawMsg = document.getElementById("withdrawMsg");
 const withdrawButton = document.getElementById("withdrawButton");
 const withdrawStatusTitleNode = document.getElementById("withdrawStatusTitle");
 const withdrawStatusBodyNode = document.getElementById("withdrawStatusBody");
-
+const userWarningCreateNewAddress = "A new address and a private key is created. Your previous back-ups do not include this newly generated address or the corresponding private key. Please use the backup feature of Arizen to make new backup file and replace your existing. By pressing OK you declare that you understand this."
 const refreshTimeout = 300;
 let refreshTimer;
 let showZeroBalances = false;
@@ -123,6 +123,11 @@ ipcRenderer.on("generate-wallet-response", (event, msgStr) => {
     const msg = JSON.parse(msgStr);
     checkResponse(msg);
     addNewAddress(msg.addr);
+    alert(userWarningCreateNewAddress)
+});
+
+ipcRenderer.on("main-sends-alert", (event, msgStr) => {
+    alert(msgStr)
 });
 
 window.addEventListener("load", initWallet);


### PR DESCRIPTION
As described in #284 

Include warning messages during:
- [x] Creation of wallet(s)
- [x] Getting new addresses
- [x] Importing new private keys (single)
- [x] Importing new private keys (file)
- [x] Backup of wallets

- [ ] Translations
- [ ] ...
