### PR TITLE
Enable login to secure node with SSH key instead of password

### DIFF
--- a/app/lang/lang_ar.json
+++ b/app/lang/lang_ar.json
@@ -169,6 +169,7 @@
       "enableDomainFronting": "Domain fronting",
       "secureNodeFQDN": "Secure Node FQDN",
       "sshPrivateKey" : "Path to SSH private key file",
+      "sshPassphrase" : "Passphrase for SSH private key file (if necessary)",
       "sshUsername": "SSH username",
       "sshPassword": "SSH password",
       "sshPort": "SSH port",

--- a/app/lang/lang_ar.json
+++ b/app/lang/lang_ar.json
@@ -168,6 +168,7 @@
       "enableNotifications": "Desktop notifications",
       "enableDomainFronting": "Domain fronting",
       "secureNodeFQDN": "Secure Node FQDN",
+      "sshPrivateKey" : "Path to SSH private key file",
       "sshUsername": "SSH username",
       "sshPassword": "SSH password",
       "sshPort": "SSH port",

--- a/app/lang/lang_bg.json
+++ b/app/lang/lang_bg.json
@@ -175,6 +175,7 @@
       "enableNotifications": "Desktop notifications",
       "enableDomainFronting": "Domain fronting",
       "secureNodeFQDN": "Secure Node FQDN",
+      "sshPrivateKey" : "Path to SSH private key file",
       "sshUsername": "SSH потребителско име",
       "sshPassword": "SSH парола",
       "sshPort": "SSH порт",

--- a/app/lang/lang_bg.json
+++ b/app/lang/lang_bg.json
@@ -176,6 +176,7 @@
       "enableDomainFronting": "Domain fronting",
       "secureNodeFQDN": "Secure Node FQDN",
       "sshPrivateKey" : "Path to SSH private key file",
+      "sshPassphrase" : "Passphrase for SSH private key file (if necessary)",
       "sshUsername": "SSH потребителско име",
       "sshPassword": "SSH парола",
       "sshPort": "SSH порт",

--- a/app/lang/lang_cs.json
+++ b/app/lang/lang_cs.json
@@ -169,6 +169,7 @@
       "enableNotifications": "Notifikace",
       "enableDomainFronting": "Domain fronting",
       "secureNodeFQDN": "Secure Node FQDN",
+      "sshPrivateKey" : "Path to SSH private key file",
       "sshUsername": "SSH jméno",
       "sshPassword": "SSH heslo",
       "sshPort": "SSH port",

--- a/app/lang/lang_cs.json
+++ b/app/lang/lang_cs.json
@@ -170,6 +170,7 @@
       "enableDomainFronting": "Domain fronting",
       "secureNodeFQDN": "Secure Node FQDN",
       "sshPrivateKey" : "Path to SSH private key file",
+      "sshPassphrase" : "Passphrase for SSH private key file (if necessary)",
       "sshUsername": "SSH jméno",
       "sshPassword": "SSH heslo",
       "sshPort": "SSH port",

--- a/app/lang/lang_de.json
+++ b/app/lang/lang_de.json
@@ -169,6 +169,7 @@
       "enableDomainFronting": "Domain Fronting",
       "secureNodeFQDN": "Secure Node FQDN",
       "sshPrivateKey" : "Pfad zur privaten SSH-Schlüssel Datei",
+      "sshPassphrase" : "Passwort zur Entschlüsselung der privaten SSH-Schlüssel Datei (falls notwendig)",
       "sshUsername": "SSH Nutzername",
       "sshPassword": "SSH Passwort",
       "sshPort": "SSH Port",

--- a/app/lang/lang_de.json
+++ b/app/lang/lang_de.json
@@ -168,6 +168,7 @@
       "enableNotifications": "Desktop-Benachrichtigungen",
       "enableDomainFronting": "Domain Fronting",
       "secureNodeFQDN": "Secure Node FQDN",
+      "sshPrivateKey" : "Pfad zur privaten SSH-Schlüssel Datei",
       "sshUsername": "SSH Nutzername",
       "sshPassword": "SSH Passwort",
       "sshPort": "SSH Port",

--- a/app/lang/lang_el.json
+++ b/app/lang/lang_el.json
@@ -169,6 +169,7 @@
       "enableDomainFronting": "Domain fronting",
       "secureNodeFQDN": "Secure Node FQDN",
       "sshPrivateKey" : "Path to SSH private key file",
+      "sshPassphrase" : "Passphrase for SSH private key file (if necessary)",
       "sshUsername": "SSH όνομα χρήστη",
       "sshPassword": "SSH κωδικός",
       "sshPort": "SSH port",

--- a/app/lang/lang_el.json
+++ b/app/lang/lang_el.json
@@ -168,6 +168,7 @@
       "enableNotifications": "Ειδοποιήσεις Επιφάνειας Εργασίας",
       "enableDomainFronting": "Domain fronting",
       "secureNodeFQDN": "Secure Node FQDN",
+      "sshPrivateKey" : "Path to SSH private key file",
       "sshUsername": "SSH όνομα χρήστη",
       "sshPassword": "SSH κωδικός",
       "sshPort": "SSH port",

--- a/app/lang/lang_en.json
+++ b/app/lang/lang_en.json
@@ -176,6 +176,7 @@
       "enableDomainFronting": "Domain fronting",
       "secureNodeFQDN": "Secure Node FQDN",
       "sshPrivateKey" : "Path to SSH private key file",
+      "sshPassphrase" : "Passphrase for SSH private key file (if necessary)",
       "sshUsername" : "SSH username",
       "sshPassword" : "SSH password",
       "sshPort" : "SSH port",

--- a/app/lang/lang_en.json
+++ b/app/lang/lang_en.json
@@ -175,6 +175,7 @@
       "enableNotifications": "Desktop notifications",
       "enableDomainFronting": "Domain fronting",
       "secureNodeFQDN": "Secure Node FQDN",
+      "sshPrivateKey" : "Path to SSH private key file",
       "sshUsername" : "SSH username",
       "sshPassword" : "SSH password",
       "sshPort" : "SSH port",

--- a/app/lang/lang_es.json
+++ b/app/lang/lang_es.json
@@ -169,6 +169,7 @@
       "enableDomainFronting": "Domain fronting",
       "secureNodeFQDN": "Secure Node FQDN",
       "sshPrivateKey" : "Path to SSH private key file",
+      "sshPassphrase" : "Passphrase for SSH private key file (if necessary)",
       "sshUsername": "SSH username",
       "sshPassword": "SSH password",
       "sshPort": "SSH port",

--- a/app/lang/lang_es.json
+++ b/app/lang/lang_es.json
@@ -168,6 +168,7 @@
       "enableNotifications": "Desktop notifications",
       "enableDomainFronting": "Domain fronting",
       "secureNodeFQDN": "Secure Node FQDN",
+      "sshPrivateKey" : "Path to SSH private key file",
       "sshUsername": "SSH username",
       "sshPassword": "SSH password",
       "sshPort": "SSH port",

--- a/app/lang/lang_fr.json
+++ b/app/lang/lang_fr.json
@@ -169,6 +169,7 @@
       "enableDomainFronting": "Domain fronting",
       "secureNodeFQDN": "Secure Node FQDN",
       "sshPrivateKey" : "Path to SSH private key file",
+      "sshPassphrase" : "Passphrase for SSH private key file (if necessary)",
       "sshUsername": "SSH username",
       "sshPassword": "SSH password",
       "sshPort": "SSH port",

--- a/app/lang/lang_fr.json
+++ b/app/lang/lang_fr.json
@@ -168,6 +168,7 @@
       "enableNotifications": "Desktop notifications",
       "enableDomainFronting": "Domain fronting",
       "secureNodeFQDN": "Secure Node FQDN",
+      "sshPrivateKey" : "Path to SSH private key file",
       "sshUsername": "SSH username",
       "sshPassword": "SSH password",
       "sshPort": "SSH port",

--- a/app/lang/lang_it.json
+++ b/app/lang/lang_it.json
@@ -175,6 +175,7 @@
       "enableNotifications": "Notifiche Desktop",
       "enableDomainFronting": "Domain fronting",
       "secureNodeFQDN": "Secure Node FQDN",
+      "sshPrivateKey" : "Path to SSH private key file",
       "sshUsername": "SSH username",
       "sshPassword": "SSH password",
       "sshPort": "SSH porta",

--- a/app/lang/lang_it.json
+++ b/app/lang/lang_it.json
@@ -176,6 +176,7 @@
       "enableDomainFronting": "Domain fronting",
       "secureNodeFQDN": "Secure Node FQDN",
       "sshPrivateKey" : "Path to SSH private key file",
+      "sshPassphrase" : "Passphrase for SSH private key file (if necessary)",
       "sshUsername": "SSH username",
       "sshPassword": "SSH password",
       "sshPort": "SSH porta",

--- a/app/lang/lang_ja.json
+++ b/app/lang/lang_ja.json
@@ -169,6 +169,7 @@
       "enableDomainFronting": "ドメインフロンティング",
       "secureNodeFQDN": "セキュアノード FQDN",
       "sshPrivateKey" : "Path to SSH private key file",
+      "sshPassphrase" : "Passphrase for SSH private key file (if necessary)",
       "sshUsername": "SSH ユーザー名",
       "sshPassword": "SSH パスワード",
       "sshPort": "SSH ポート",

--- a/app/lang/lang_ja.json
+++ b/app/lang/lang_ja.json
@@ -168,6 +168,7 @@
       "enableNotifications": "デスクトップ通知",
       "enableDomainFronting": "ドメインフロンティング",
       "secureNodeFQDN": "セキュアノード FQDN",
+      "sshPrivateKey" : "Path to SSH private key file",
       "sshUsername": "SSH ユーザー名",
       "sshPassword": "SSH パスワード",
       "sshPort": "SSH ポート",

--- a/app/lang/lang_ko.json
+++ b/app/lang/lang_ko.json
@@ -168,6 +168,7 @@
       "enableNotifications": "데스크탑 알림",
       "enableDomainFronting": "도메인 프론팅",
       "secureNodeFQDN": "보안 노드 FQDN",
+      "sshPrivateKey" : "Path to SSH private key file",
       "sshUsername": "SSH 사용자 이름",
       "sshPassword": "SSH 비밀번호",
       "sshPort": "SSH 포트",

--- a/app/lang/lang_ko.json
+++ b/app/lang/lang_ko.json
@@ -169,6 +169,7 @@
       "enableDomainFronting": "도메인 프론팅",
       "secureNodeFQDN": "보안 노드 FQDN",
       "sshPrivateKey" : "Path to SSH private key file",
+      "sshPassphrase" : "Passphrase for SSH private key file (if necessary)",
       "sshUsername": "SSH 사용자 이름",
       "sshPassword": "SSH 비밀번호",
       "sshPort": "SSH 포트",

--- a/app/lang/lang_nl.json
+++ b/app/lang/lang_nl.json
@@ -169,6 +169,7 @@
       "enableDomainFronting": "Domain-fronting",
       "secureNodeFQDN": "Secure Node FQDN",
       "sshPrivateKey" : "Path to SSH private key file",
+      "sshPassphrase" : "Passphrase for SSH private key file (if necessary)",
       "sshUsername": "SSH gebruikersnaam",
       "sshPassword": "SSH wachtwoord",
       "sshPort": "SSH poort",

--- a/app/lang/lang_nl.json
+++ b/app/lang/lang_nl.json
@@ -168,6 +168,7 @@
       "enableNotifications": "Bureaublad notificaties",
       "enableDomainFronting": "Domain-fronting",
       "secureNodeFQDN": "Secure Node FQDN",
+      "sshPrivateKey" : "Path to SSH private key file",
       "sshUsername": "SSH gebruikersnaam",
       "sshPassword": "SSH wachtwoord",
       "sshPort": "SSH poort",

--- a/app/lang/lang_pl.json
+++ b/app/lang/lang_pl.json
@@ -169,6 +169,7 @@
       "enableDomainFronting": "Domain fronting",
       "secureNodeFQDN": "Secure Node FQDN",
       "sshPrivateKey" : "Path to SSH private key file",
+      "sshPassphrase" : "Passphrase for SSH private key file (if necessary)",
       "sshUsername": "SSH username",
       "sshPassword": "SSH password",
       "sshPort": "SSH port",

--- a/app/lang/lang_pl.json
+++ b/app/lang/lang_pl.json
@@ -168,6 +168,7 @@
       "enableNotifications": "Desktop notifications",
       "enableDomainFronting": "Domain fronting",
       "secureNodeFQDN": "Secure Node FQDN",
+      "sshPrivateKey" : "Path to SSH private key file",
       "sshUsername": "SSH username",
       "sshPassword": "SSH password",
       "sshPort": "SSH port",

--- a/app/lang/lang_pt.json
+++ b/app/lang/lang_pt.json
@@ -169,6 +169,7 @@
       "enableDomainFronting": "Domain fronting",
       "secureNodeFQDN": "Secure Node FQDN",
       "sshPrivateKey" : "Path to SSH private key file",
+      "sshPassphrase" : "Passphrase for SSH private key file (if necessary)",
       "sshUsername": "SSH username",
       "sshPassword": "SSH password",
       "sshPort": "SSH port",

--- a/app/lang/lang_pt.json
+++ b/app/lang/lang_pt.json
@@ -168,6 +168,7 @@
       "enableNotifications": "Desktop notifications",
       "enableDomainFronting": "Domain fronting",
       "secureNodeFQDN": "Secure Node FQDN",
+      "sshPrivateKey" : "Path to SSH private key file",
       "sshUsername": "SSH username",
       "sshPassword": "SSH password",
       "sshPort": "SSH port",

--- a/app/lang/lang_ru.json
+++ b/app/lang/lang_ru.json
@@ -169,6 +169,7 @@
       "enableDomainFronting": "Domain fronting",
       "secureNodeFQDN": "Secure Node FQDN",
       "sshPrivateKey" : "Path to SSH private key file",
+      "sshPassphrase" : "Passphrase for SSH private key file (if necessary)",
       "sshUsername": "SSH username",
       "sshPassword": "SSH password",
       "sshPort": "SSH port",

--- a/app/lang/lang_ru.json
+++ b/app/lang/lang_ru.json
@@ -168,6 +168,7 @@
       "enableNotifications": "Desktop notifications",
       "enableDomainFronting": "Domain fronting",
       "secureNodeFQDN": "Secure Node FQDN",
+      "sshPrivateKey" : "Path to SSH private key file",
       "sshUsername": "SSH username",
       "sshPassword": "SSH password",
       "sshPort": "SSH port",

--- a/app/lang/lang_sr.json
+++ b/app/lang/lang_sr.json
@@ -175,6 +175,7 @@
       "enableNotifications": "Desktop obaveštenja",
       "enableDomainFronting": "Domain fronting",
       "secureNodeFQDN": "Sigurnosni Nod FQDN",
+      "sshPrivateKey" : "Path to SSH private key file",
       "sshUsername": "SSH korisnik",
       "sshPassword": "SSH lozinka",
       "sshPort": "SSH port",

--- a/app/lang/lang_sr.json
+++ b/app/lang/lang_sr.json
@@ -176,6 +176,7 @@
       "enableDomainFronting": "Domain fronting",
       "secureNodeFQDN": "Sigurnosni Nod FQDN",
       "sshPrivateKey" : "Path to SSH private key file",
+      "sshPassphrase" : "Passphrase for SSH private key file (if necessary)",
       "sshUsername": "SSH korisnik",
       "sshPassword": "SSH lozinka",
       "sshPort": "SSH port",

--- a/app/lang/lang_tr.json
+++ b/app/lang/lang_tr.json
@@ -169,6 +169,7 @@
       "enableDomainFronting": "Domain fronting",
       "secureNodeFQDN": "Secure Node FQDN",
       "sshPrivateKey" : "Path to SSH private key file",
+      "sshPassphrase" : "Passphrase for SSH private key file (if necessary)",
       "sshUsername": "SSH username",
       "sshPassword": "SSH password",
       "sshPort": "SSH port",

--- a/app/lang/lang_tr.json
+++ b/app/lang/lang_tr.json
@@ -168,6 +168,7 @@
       "enableNotifications": "Desktop notifications",
       "enableDomainFronting": "Domain fronting",
       "secureNodeFQDN": "Secure Node FQDN",
+      "sshPrivateKey" : "Path to SSH private key file",
       "sshUsername": "SSH username",
       "sshPassword": "SSH password",
       "sshPort": "SSH port",

--- a/app/lang/lang_vi.json
+++ b/app/lang/lang_vi.json
@@ -169,6 +169,7 @@
       "enableDomainFronting": "Domain fronting",
       "secureNodeFQDN": "Secure Node FQDN",
       "sshPrivateKey" : "Path to SSH private key file",
+      "sshPassphrase" : "Passphrase for SSH private key file (if necessary)",
       "sshUsername": "SSH username",
       "sshPassword": "SSH password",
       "sshPort": "SSH port",

--- a/app/lang/lang_vi.json
+++ b/app/lang/lang_vi.json
@@ -168,6 +168,7 @@
       "enableNotifications": "Desktop notifications",
       "enableDomainFronting": "Domain fronting",
       "secureNodeFQDN": "Secure Node FQDN",
+      "sshPrivateKey" : "Path to SSH private key file",
       "sshUsername": "SSH username",
       "sshPassword": "SSH password",
       "sshPort": "SSH port",

--- a/app/lang/lang_zh_cn.json
+++ b/app/lang/lang_zh_cn.json
@@ -169,6 +169,7 @@
       "enableDomainFronting": "Domain fronting",
       "secureNodeFQDN": "Secure Node FQDN",
       "sshPrivateKey" : "Path to SSH private key file",
+      "sshPassphrase" : "Passphrase for SSH private key file (if necessary)",
       "sshUsername": "SSH username",
       "sshPassword": "SSH password",
       "sshPort": "SSH port",

--- a/app/lang/lang_zh_cn.json
+++ b/app/lang/lang_zh_cn.json
@@ -168,6 +168,7 @@
       "enableNotifications": "Desktop notifications",
       "enableDomainFronting": "Domain fronting",
       "secureNodeFQDN": "Secure Node FQDN",
+      "sshPrivateKey" : "Path to SSH private key file",
       "sshUsername": "SSH username",
       "sshPassword": "SSH password",
       "sshPort": "SSH port",

--- a/app/lang/lang_zh_tw.json
+++ b/app/lang/lang_zh_tw.json
@@ -169,6 +169,7 @@
       "enableDomainFronting": "Domain fronting",
       "secureNodeFQDN": "Secure Node FQDN",
       "sshPrivateKey" : "Path to SSH private key file",
+      "sshPassphrase" : "Passphrase for SSH private key file (if necessary)",
       "sshUsername": "SSH username",
       "sshPassword": "SSH password",
       "sshPort": "SSH port",

--- a/app/lang/lang_zh_tw.json
+++ b/app/lang/lang_zh_tw.json
@@ -168,6 +168,7 @@
       "enableNotifications": "Desktop notifications",
       "enableDomainFronting": "Domain fronting",
       "secureNodeFQDN": "Secure Node FQDN",
+      "sshPrivateKey" : "Path to SSH private key file",
       "sshUsername": "SSH username",
       "sshPassword": "SSH password",
       "sshPort": "SSH port",

--- a/app/ssh_tunneling.js
+++ b/app/ssh_tunneling.js
@@ -12,6 +12,7 @@ async function openTunnel() {
         host: settings.secureNodeFQDN,// SSH server //settings.secureNodeFQDN,
         port: settings.sshPort, // SSH port
         // keepAlive:true,
+        privateKey: settings.sshPrivateKey, //settings.secureNodeSshPrivateKey,
         username: settings.sshUsername, //settings.secureNodeUsername,
         password: settings.sshPassword, //settings.secureNodePassword,
         srcPort: settings.secureNodePort, // Arizen localhost port //settings.secureNodePort

--- a/app/ssh_tunneling.js
+++ b/app/ssh_tunneling.js
@@ -4,6 +4,7 @@
 "use strict";
 
 const openSshTunnel = require("open-ssh-tunnel");
+const fs = require('fs-extra');
 
 const localHost = "127.0.0.1";
 
@@ -12,7 +13,8 @@ async function openTunnel() {
         host: settings.secureNodeFQDN,// SSH server //settings.secureNodeFQDN,
         port: settings.sshPort, // SSH port
         // keepAlive:true,
-        privateKey: settings.sshPrivateKey, //settings.secureNodeSshPrivateKey,
+        privateKey: fs.readFileSync(settings.sshPrivateKey), //settings.secureNodeSshPrivateKey,
+        passphrase: settings.sshPassphrase, //settings.secureNodeSshPassphrase,
         username: settings.sshUsername, //settings.secureNodeUsername,
         password: settings.sshPassword, //settings.secureNodePassword,
         srcPort: settings.secureNodePort, // Arizen localhost port //settings.secureNodePort

--- a/app/zcommon.js
+++ b/app/zcommon.js
@@ -302,6 +302,7 @@ function syncZaddrIfSettingsExist() {
         settings.secureNodePassword &&
         settings.sshUsername &&
         settings.sshPassword &&
+        settings.sshPrivateKey &&
         settings.sshPort) {
         rpc.importAllZAddressesFromSNtoArizenExcludeExisting();
         rpc.importAllZAddressesFromArizenToSN();
@@ -369,6 +370,7 @@ function showSettingsDialog() {
         const inputSecureNodeUsername = dialog.querySelector(".settingsSecureNodeUsername");
         const inputSecureNodePassword = dialog.querySelector(".settingsSecureNodePassword");
 
+        const inputSshPrivateKey = dialog.querySelector(".settingsSshPrivateKey");
         const inputSshUsername = dialog.querySelector(".settingsSshUsername");
         const inputSshPassword = dialog.querySelector(".settingsSshPassword");
         const inputSshPort = dialog.querySelector(".settingsSshPort");
@@ -395,6 +397,7 @@ function showSettingsDialog() {
         inputSecureNodePort.value = settings.secureNodePort || 8231;
         inputSecureNodeUsername.value = settings.secureNodeUsername || "";
         inputSecureNodePassword.value = settings.secureNodePassword || "";
+        inputSshPrivateKey.value = settings.sshPrivateKey || "";
         inputSshUsername.value = settings.sshUsername || "";
         inputSshPassword.value = settings.sshPassword || "";
         inputSshPort.value = settings.sshPort || 22;
@@ -418,6 +421,7 @@ function showSettingsDialog() {
                 secureNodePort: inputSecureNodePort.value,
                 secureNodeUsername: inputSecureNodeUsername.value,
                 secureNodePassword: inputSecureNodePassword.value,
+                sshPrivateKey: inputSshPrivateKey.value,
                 sshUsername: inputSshUsername.value,
                 sshPassword: inputSshPassword.value,
                 sshPort: inputSshPort.value,

--- a/app/zcommon.js
+++ b/app/zcommon.js
@@ -303,6 +303,7 @@ function syncZaddrIfSettingsExist() {
         settings.sshUsername &&
         settings.sshPassword &&
         settings.sshPrivateKey &&
+        settings.sshPassphrase &&
         settings.sshPort) {
         rpc.importAllZAddressesFromSNtoArizenExcludeExisting();
         rpc.importAllZAddressesFromArizenToSN();
@@ -370,6 +371,7 @@ function showSettingsDialog() {
         const inputSecureNodeUsername = dialog.querySelector(".settingsSecureNodeUsername");
         const inputSecureNodePassword = dialog.querySelector(".settingsSecureNodePassword");
 
+        const inputSshPassphrase = dialog.querySelector(".settingsSshPassphrase");
         const inputSshPrivateKey = dialog.querySelector(".settingsSshPrivateKey");
         const inputSshUsername = dialog.querySelector(".settingsSshUsername");
         const inputSshPassword = dialog.querySelector(".settingsSshPassword");
@@ -397,6 +399,7 @@ function showSettingsDialog() {
         inputSecureNodePort.value = settings.secureNodePort || 8231;
         inputSecureNodeUsername.value = settings.secureNodeUsername || "";
         inputSecureNodePassword.value = settings.secureNodePassword || "";
+        inputSshPassphrase.value = settings.sshPassphrase || "";
         inputSshPrivateKey.value = settings.sshPrivateKey || "";
         inputSshUsername.value = settings.sshUsername || "";
         inputSshPassword.value = settings.sshPassword || "";
@@ -421,6 +424,7 @@ function showSettingsDialog() {
                 secureNodePort: inputSecureNodePort.value,
                 secureNodeUsername: inputSecureNodeUsername.value,
                 secureNodePassword: inputSecureNodePassword.value,
+                sshPassphrase: inputSshPassphrase.value,
                 sshPrivateKey: inputSshPrivateKey.value,
                 sshUsername: inputSshUsername.value,
                 sshPassword: inputSshPassword.value,

--- a/app/zwallet.html
+++ b/app/zwallet.html
@@ -333,6 +333,8 @@
 
                 <label for=secureNodeFQDN data-tr=wallet.settings.secureNodeFQDN>Secure Node FQDN</label>
                 <input type=text name=settingsSecureNodeFQDN class=settingsSecureNodeFQDN />
+                <label for=sshPrivateKey data-tr=wallet.settings.sshPrivateKey>Path to SSH private key file</label>
+                <input type=text name=settingsSshPrivateKey class=settingsSshPrivateKey />
                 <label for=sshUsername data-tr=wallet.settings.sshUsername>SSH username</label>
                 <input type=text name=settingsSshUsername class=settingsSshUsername />
                 <label for=sshPassword data-tr=wallet.settings.sshPassword>SSH password</label>

--- a/app/zwallet.html
+++ b/app/zwallet.html
@@ -336,7 +336,7 @@
                 <label for=sshPrivateKey data-tr=wallet.settings.sshPrivateKey>Path to SSH private key file</label>
                 <input type=text name=settingsSshPrivateKey class=settingsSshPrivateKey />
                 <label for=sshPassphrase data-tr=wallet.settings.sshPassphrase>Passphrase for SSH private key file (if necessary)</label>
-                <input type=text name=settingsSshPassphrase class=settingsSshPassphrase />
+                <input type=password name=settingsSshPassphrase class=settingsSshPassphrase />
                 <label for=sshUsername data-tr=wallet.settings.sshUsername>SSH username</label>
                 <input type=text name=settingsSshUsername class=settingsSshUsername />
                 <label for=sshPassword data-tr=wallet.settings.sshPassword>SSH password</label>

--- a/app/zwallet.html
+++ b/app/zwallet.html
@@ -335,6 +335,8 @@
                 <input type=text name=settingsSecureNodeFQDN class=settingsSecureNodeFQDN />
                 <label for=sshPrivateKey data-tr=wallet.settings.sshPrivateKey>Path to SSH private key file</label>
                 <input type=text name=settingsSshPrivateKey class=settingsSshPrivateKey />
+                <label for=sshPassphrase data-tr=wallet.settings.sshPassphrase>Passphrase for SSH private key file (if necessary)</label>
+                <input type=text name=settingsSshPassphrase class=settingsSshPassphrase />
                 <label for=sshUsername data-tr=wallet.settings.sshUsername>SSH username</label>
                 <input type=text name=settingsSshUsername class=settingsSshUsername />
                 <label for=sshPassword data-tr=wallet.settings.sshPassword>SSH password</label>

--- a/release.json
+++ b/release.json
@@ -2,5 +2,5 @@
   "url": "https://github.com/ZencashOfficial/arizen/releases/download/v1.1.8/Arizen-1.1.8-mac.zip",
   "name": "1.1.8",
   "notes": "1st Version",
-  "pub_date": "15-6-2018"
+  "pub_date": "12-6-2018"
 }


### PR DESCRIPTION
This PR enables the user to configure the login to his Secure Node via a SSH key file.

Using a private key to login to the Secure Node greatly improves security, as it allows the Secure Node host admin to disable password-based logins completely and thus removes possible attack vectors.

fixes #334 