### PR TITLE
Actually use the API URL from settings (only the top one for now)

### DIFF
--- a/app/main.js
+++ b/app/main.js
@@ -458,8 +458,11 @@ function setSettings(newSettings) {
         });
     }
     else {
+        var apiUrl = settings.apiUrls[0];
+        console.log("Current API URL: " + apiUrl);
         axiosApi = axios.create({
-            baseURL: "https://explorer.zensystem.io/insight-api-zen",
+            // take the first URL from the API URLs list for now
+            baseURL: apiUrl,
             timeout: 30000,
         });
     }


### PR DESCRIPTION
Previous API URL was hardcoded when the axios object was created. This was a huge problem when that URL was down (or giving problems via CloudFlare). For now only the top URL in the list is used.